### PR TITLE
Issue#118 - Remove glossaryItem from sections

### DIFF
--- a/official/PianoDiQualifica/res/sections/administrativeManagementOfTheReview.tex
+++ b/official/PianoDiQualifica/res/sections/administrativeManagementOfTheReview.tex
@@ -1,5 +1,5 @@
 \section{Gestione amministrativa della revisione}
-\subsection{Comunicazione delle \glossaryItem{anomalie}}
+\subsection{Comunicazione delle anomalie}
 Il \glossaryItem{processo} di Software Quality Management è finalizzato alla ricerca dei difetti. L'identificazione delle \glossaryItem{anomalie} mantiene aggiornato il Responsabile sullo stato del prodotto, e permette di prendere dei provvedimenti per correggerle. A tal fine, è utile distinguere e catalogare le \glossaryItem{anomalie}, per discuterne durante revisioni e riunioni. Il \glossaryItem{team} ha scelto di adottare le definizioni di \glossaryItem{anomalie} presenti nello standard IEEE 610.12-90:
 \begin{itemize}
 \item \textbf{Error}: differenza riscontrata tra il risultato di una computazione e il valore teorico atteso (e.g. uscita dal range di accettazione degli indici di misurazione);
@@ -9,7 +9,7 @@ Il \glossaryItem{processo} di Software Quality Management è finalizzato alla ri
 \end{itemize}
 Questa catalogazione permette di definire delle metriche in grado di valutare l'andamento del prodotto e, in alcuni casi, di predirlo. Un esempio è la metrica che conteggia il numero di bug per linee di codice.
 
-\subsection{Controlli per la \glossaryItem{qualità} di \glossaryItem{processo}}
+\subsection{Controlli per la qualità di processo}
 Le procedure di controllo per la \glossaryItem{qualità} di \glossaryItem{processo} sono finalizzate a migliorare la \glossaryItem{qualità} del prodotto e/o diminuire i costi e tempi di sviluppo. Esistono due approcci principali:
 \begin{itemize}
 \item \textbf{A maturità di \glossaryItem{processo}}: l'obiettivo primario è la \glossaryItem{qualità} del prodotto e la prevedibilità dei processi;

--- a/official/PianoDiQualifica/res/sections/generalVision.tex
+++ b/official/PianoDiQualifica/res/sections/generalVision.tex
@@ -1,8 +1,8 @@
-\section{Visione generale della strategia di \glossaryItem{verifica}}
+\section{Visione generale della strategia di verifica}
 La volontà del \glossaryItem{team} è quella di automatizzare il più possibile il lavoro di \glossaryItem{verifica}. Saranno quindi utilizzati dei \glossaryItem{tool}s adeguatamente configurati, con lo scopo di avere un riscontro affidabile e quantitativo che permetta di assicurare il grado di \glossaryItem{qualità} voluto. 
 
 \subsection{Definizione degli obiettivi}
-\subsubsection{\glossaryItem{Qualità} di \glossaryItem{processo}}
+\subsubsection{Qualità di processo}
 Molto spesso prodotti scadenti derivano da processi scadenti. Per questo motivo, e per le seguenti ragioni, assicurare la \glossaryItem{qualità} dei processi è un obiettivo primario per il \glossaryItem{team} BugBusters:
 \begin{itemize}
 	\item aiuta ad ottimizzare l'uso di risorse;
@@ -16,11 +16,11 @@ Si è dunque deciso di perseguire la \glossaryItem{qualità} servendosi dei segu
 	\item \glossaryItem{PDCA}\footnote{Si veda appendice \ref{AppPDCA} per approfondimenti} (\textbf{P}lan \textbf{D}o \textbf{C}hek \textbf{A}ct): per il controllo delle attività di \glossaryItem{processo} ripetibili e misurabili e per la manutenibilità dei processi stessi incrementandone la \glossaryItem{qualità}.
 \end{itemize}
 
-\subsubsection{\glossaryItem{Qualità} di prodotto}
+\subsubsection{Qualità di prodotto}
 Lo standard ISO/IEC 9126\footnote{Si veda appendice \ref{AppQualitaProdotto} per approfondimenti} classifica la \glossaryItem{qualità} del software e definisce delle metriche per la sua misurazione. Il \glossaryItem{team} BugBusters ha scelto di utilizzare queste metriche, al fine di assicurare la \glossaryItem{qualità} del prodotto finale.
 
 \subsection{Procedure di controllo}
-\subsubsection{\glossaryItem{Qualità} di \glossaryItem{processo}}
+\subsubsection{Qualità di processo}
 La pianificazione delle attività volte al miglioramento continuo dei processi sono descritte nel \PianoDiProgetto. Le linee guida per la gestione della \glossaryItem{qualità} del \glossaryItem{processo}, invece, seguono il modello PDCA e descrivono come devono essere attuate le procedure di controllo:
 \begin{itemize}
 	\item la pianificazione deve essere dettagliata, e le attività pianificate devono essere monitorate;
@@ -28,7 +28,7 @@ La pianificazione delle attività volte al miglioramento continuo dei processi s
 	\item il miglioramento della \glossaryItem{qualità} del \glossaryItem{processo} deve essere verificato attraverso l'utilizzo di apposite metriche, che verranno descritte in seguito.
 \end{itemize}
 
-\subsubsection{\glossaryItem{Qualità} di prodotto}
+\subsubsection{Qualità di prodotto}
 Il controllo per la \glossaryItem{qualità} del prodotto definisce i seguenti processi:
 \begin{itemize}
 	\item \textbf{SQA} (\textbf{S}oftware \textbf{Q}uality \textbf{A}ssurance): si occupa di assicurare che i processi siano implementati secondo quanto pianificato e che siano forniti sistemi di misurazione dei processi;

--- a/official/PianoDiQualifica/res/sections/quality.tex
+++ b/official/PianoDiQualifica/res/sections/quality.tex
@@ -1,4 +1,4 @@
-\section{Standard di \glossaryItem{qualità}} 
+\section{Standard di qualità}
 \subsection{Standard ISO/IEC 15504}\label{AppQualitaProcessi}
 ISO/IEC 15504 denominato anche \textbf{\glossaryItem{SPICE}}, consiste di un insieme di normative e linee guida per lo sviluppo di processi software.
 Definisce un modello di riferimento per dare una valutazione complessiva della maturità dei processi in un'organizzazione del settore IT.\\

--- a/official/PianoDiQualifica/res/sections/verificationActivitiesReport.tex
+++ b/official/PianoDiQualifica/res/sections/verificationActivitiesReport.tex
@@ -1,6 +1,6 @@
 \newpage
-\section{Resoconto delle attività di \glossaryItem{verifica}} \label{App:AppendixA}
-	\subsection{Riassunto delle attività di \glossaryItem{verifica}} \label{App:AppendixA}
+\section{Resoconto delle attività di verifica} \label{App:AppendixA}
+	\subsection{Riassunto delle attività di verifica} \label{App:AppendixA}
 		\subsubsection{Revisione dei requisiti} \label{App:AppendixA}
 			
 			L'attività di \glossaryItem{verifica} svolta dai verificatori è avvenuta come determinato dal \PianoDiProgetto al termine della stesura di ogni documento in ingresso alla revisione dei requisiti.


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #118 

_Breve descrizione della soluzione adottata_:
Rimossi i comandi \glossaryItem dai titoli
