### PR TITLE
Issue #317 - Move minimum requirements in requisiti.tex

### DIFF
--- a/official/AnalisiDeiRequisiti/res/sections/descrizione_generale.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/descrizione_generale.tex
@@ -39,11 +39,4 @@ Le entit\`a (e le relazioni esistenti tra di loro) definite nel modello \glossar
 		\end{description}
 \end{description}
 
-\subsection{Vincoli generali sul \textit{software}}
-Il gruppo ha individuato i seguenti requisiti minimi sui \textit{browser} supportati da \glossaryItem{MaaS}:
-\begin{itemize}
-\item textbf{\textit{Google Chrome}}, \glossaryItem{versione} 48.x;
-\item textbf{\textit{Mozilla Firefox}}, \glossaryItem{versione} 45.x.
-\end{itemize}
-
 \newpage

--- a/official/AnalisiDeiRequisiti/res/sections/requisiti.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/requisiti.tex
@@ -268,10 +268,12 @@ Dove:
 & Capitolato \\ \hline
     R4O 3 & Vincolo \newline Obbligatorio &  Obbligo di effettuare il \glossaryItem{deployment} su \glossaryItem{Heroku}.
       & Capitolato \\ \hline
+      
+    R4O 4 & Vincolo \newline Obbligatorio &  I browser supportati per eseguire l'applicazione sono \textbf{\textit{Google Chrome}} versione 49.X e \textbf{\textit{Mozilla Firefox}} versione 45.Y.
+        & Riunione interna \verbalRI{21-03-2016}{1} \\ \hline
     \end{longtable}
   \egroup
-\end{center}   
-
+\end{center}  
 \subsection{Tracciamento requisiti-fonti}
 
 \begin{center}


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #317

_Breve descrizione della soluzione adottata_:
Spostati i requisiti minimi da "descrizione_generale.tex" a requisiti.tex, nella parte dei requisiti di vincolo (come detto dal prof)
