### PR TITLE
Issue#280 - Sistemare Iniziali Titoli

### DIFF
--- a/official/AnalisiDeiRequisiti/res/sections/editor.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/editor.tex
@@ -2,7 +2,7 @@
 
 Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'editor.
 
-\subsection{Casi d'Uso}
+\subsection{Casi d'uso}
 
 
 \subsubsection{Operazioni ad alto livello - Uso dell'editor}

--- a/official/AnalisiDeiRequisiti/res/sections/editor.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/editor.tex
@@ -599,7 +599,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'editor.
     \end{center}
     
     
-\subsubsection{Aggiungere/Rimuovere un attributo \glossaryItem{Row}}
+\subsubsection{Aggiungere/Rimuovere un attributo Row}
 
     %Tabella 
     \begin{center}

--- a/official/AnalisiDeiRequisiti/res/sections/superadmin.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/superadmin.tex
@@ -7,7 +7,7 @@ Di seguito vengono elencati i \glossaryItem{casi} d'uso per il \glossaryItem{Sup
 %d’uso devono avere associata una relativa descrizione (come fatto fino a
 %questo punto).''
 
-\subsection{Casi d'Uso}
+\subsection{Casi d'uso}
 
 \subsubsection{Interazione ad alto livello tra sistema e super-admin}
 

--- a/official/AnalisiDeiRequisiti/res/sections/superadmin.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/superadmin.tex
@@ -9,7 +9,7 @@ Di seguito vengono elencati i \glossaryItem{casi} d'uso per il \glossaryItem{Sup
 
 \subsection{Casi d'Uso}
 
-\subsubsection{Interazione ad alto livello tra sistema e Super-Admin}
+\subsubsection{Interazione ad alto livello tra sistema e super-admin}
 
     \begin{figure}[h]
       \begin{center}
@@ -103,7 +103,7 @@ Di seguito vengono elencati i \glossaryItem{casi} d'uso per il \glossaryItem{Sup
     \end{center}
 
 
-\subsubsection{Creazione di una nuova Company - inserimento dell'email dell'Owner della nuova Company}
+\subsubsection{Creazione di una nuova Company - inserimento dell'email dell'owner della nuova Company}
     
     %Tabella 
     \begin{center}
@@ -407,7 +407,7 @@ Di seguito vengono elencati i \glossaryItem{casi} d'uso per il \glossaryItem{Sup
     \end{center}
 
 
-\subsubsection{Gestione degli altri Super-Admin}
+\subsubsection{Gestione degli altri super-admin}
     \begin{figure}[H]
       \begin{center}
         \includegraphics[width=12cm]{res/img/UCSuperadmin/UC-S3.png}
@@ -442,7 +442,7 @@ vedere in un elenco quelli già presenti e vederne le informazioni in dettaglio 
     \end{center}
 
 
-\subsubsection{Creazione di un Super-Admin}
+\subsubsection{Creazione di un super-admin}
     \begin{figure}[H]
       \begin{center}
         \includegraphics[width=12cm]{res/img/UCSuperadmin/UC-S3.0.png}

--- a/official/AnalisiDeiRequisiti/res/sections/utenteA.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/utenteA.tex
@@ -1,7 +1,7 @@
 \section{Utente autenticato}
 
 Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato.
-\subsection{Casi d'Uso}
+\subsection{Casi d'uso}
 
 \subsubsection{Operazioni dell'utente autenticato}
 

--- a/official/AnalisiDeiRequisiti/res/sections/utenteA.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/utenteA.tex
@@ -1,9 +1,9 @@
-\section{Utente Autenticato}
+\section{Utente autenticato}
 
 Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato.
 \subsection{Casi d'Uso}
 
-\subsubsection{Operazioni dell'Utente Autenticato}
+\subsubsection{Operazioni dell'utente autenticato}
 
     \begin{figure}[H]
       \begin{center}
@@ -153,7 +153,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Inserimento Password}
+\subsubsection{Inserimento password}
 
     %Tabella 
     \begin{center}
@@ -515,7 +515,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
           \end{longtable}
           \egroup
         \end{center}
-\subsubsection{Operazioni sugli Utenti}
+\subsubsection{Operazioni sugli utenti}
 
         \begin{figure}[H]
           \begin{center}
@@ -1398,7 +1398,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center} 
     
-\subsubsection{Inserimento Nome Database}
+\subsubsection{Inserimento nome database}
 
     %Tabella 
     \begin{center}
@@ -1420,7 +1420,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}    
 
-\subsubsection{Inserimento Host Database}
+\subsubsection{Inserimento host database}
 
     %Tabella 
     \begin{center}
@@ -1442,7 +1442,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Inserimento Porta Database}
+\subsubsection{Inserimento porta database}
 
     %Tabella 
     \begin{center}
@@ -1574,7 +1574,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
             \egroup
           \end{center}
           
-\subsubsection{Modifica Username Database}
+\subsubsection{Modifica username database}
 
     %Tabella 
     \begin{center}
@@ -1596,7 +1596,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Modifica Password Database}
+\subsubsection{Modifica password database}
 
     %Tabella 
     \begin{center}
@@ -1695,7 +1695,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
 
-\subsubsection{Modifica accessibilità per Members}
+\subsubsection{Modifica accessibilità per members}
 
     %Tabella 
     \begin{center}
@@ -1779,7 +1779,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
     \end{center} 
     
     \newpage
-\subsubsection{Inserimento Nome Database}
+\subsubsection{Inserimento nome database}
 
     %Tabella 
     \begin{center}
@@ -1801,7 +1801,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}    
 
-\subsubsection{Inserimento Host Database}
+\subsubsection{Inserimento host database}
 
     %Tabella 
     \begin{center}
@@ -1823,7 +1823,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Inserimento Porta Database}
+\subsubsection{Inserimento porta database}
 
     %Tabella 
     \begin{center}
@@ -1845,7 +1845,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Inserimento Username Database}
+\subsubsection{Inserimento username database}
 
     %Tabella 
     \begin{center}
@@ -1867,7 +1867,7 @@ Di seguito vengono elencati i \glossaryItem{casi d'uso} per l'Utente Autenticato
       \egroup
     \end{center}
     
-\subsubsection{Inserimento Password Database}
+\subsubsection{Inserimento password database}
 
     %Tabella 
     \begin{center}

--- a/official/AnalisiDeiRequisiti/res/sections/utenteNA.tex
+++ b/official/AnalisiDeiRequisiti/res/sections/utenteNA.tex
@@ -1,4 +1,4 @@
-\section{Utente Non Autenticato}
+\section{Utente non autenticato}
 %1)who is he? add a reference/description to this actor in the general description's list of roles
 %2) È corretto
    %dal punto di vista della sicurezza che un utente non ancora identificato
@@ -183,7 +183,7 @@ L'utente non autenticato ha visualizzato la pagina per la creazione dell'account
       \egroup
     \end{center} 
 
-\subsubsection{Registrazione Utente}
+\subsubsection{Registrazione utente}
 
     \begin{figure}[H]
       \begin{center}

--- a/official/NormeDiProgetto/res/sections/supportProcesses.tex
+++ b/official/NormeDiProgetto/res/sections/supportProcesses.tex
@@ -183,7 +183,7 @@ In cui:
 \subsection{Processo di verifica}
 \subsubsection{Scopo del processo}
 Tale \glossaryItem{processo} ha come obiettivo confermare che ogni componente prodotta durante il \glossaryItem{ciclo di vita del software} sia conforme agli standard decisi dal \glossaryItem{team}.
-\subsubsection{Risultati attesi dal Processo}
+\subsubsection{Risultati attesi dal processo}
 Il \glossaryItem{processo} di \glossaryItem{verifica} deve raggiungere questi obiettivi:
 \begin{itemize}
 \item Individuazione e applicazione di una strategia per la \glossaryItem{verifica};

--- a/official/PianoDiProgetto/res/sections/preventivoAFinire.tex
+++ b/official/PianoDiProgetto/res/sections/preventivoAFinire.tex
@@ -1,4 +1,4 @@
-\section{Preventivo a Finire}
+\section{Preventivo a finire}
 Di seguito è riportato il preventivo a finire complessivo dei periodi di \textit{Progettazione di Dettaglio e Codifica} e \textit{Validazione}.
 
 \begin{table}[H]

--- a/official/PianoDiQualifica/res/sections/integrationTest.tex
+++ b/official/PianoDiQualifica/res/sections/integrationTest.tex
@@ -1,7 +1,7 @@
 \newpage
 %introduction
 %write here
-\subsection{Test di Integrazione}
+\subsection{Test di integrazione}
 Questa tipologia di test è utile alla \glossaryItem{verifica} del corretto funzionamento delle componenti definite in sede di \SpecificaTecnica.
 Verrà utilizzata la seguente notazione:
 	\begin{center}

--- a/official/PianoDiQualifica/res/sections/testDesign.tex
+++ b/official/PianoDiQualifica/res/sections/testDesign.tex
@@ -7,11 +7,11 @@
 	Il testing del software viene suddiviso in livelli differenti, che si concretizzano in un'esecuzione bottom-up che avanza sequenzialmente alle attività di codifica e di \glossaryItem{validazione}. I test da effettuare sul prodotto sono di cinque tipi, ma gli ultimi due saranno specificati nella prossima revisione:
 
 \begin{enumerate}
-	\item Test di \glossaryItem{Validazione} (TV): viene verificato che il prodotto soddisfi quanto richiesto dal proponente individuando delle macro azioni che un utente svolge comunemente sul sistema;
-	\item Test di Sistema (TS): sono test relativi al comportamento dell’intero sistema. Viene verificato che l'architettura generale funzioni complessivamente bene;
-	\item Test di Integrazione (TI): vengono verificate le componenti del sistema contenute nella \SpecificaTecnica, ossia viene verificato che i \glossaryItem{package} siano funzionanti e in grado di funzionare nel loro insieme;
-	\item Test di Unità (TU): viene testata ogni unità, ossia la più piccola parte di lavoro assegnabile ad un \glossaryItem{programmatore}. In questo \glossaryItem{progetto} una unità dovrebbe corrispondere ad una function o a un method;
-	\item Test di Regressione (TR): possono essere test di tutte le tipologie succitate, e devono mostrare il funzionamento del prodotto a seguito di una modifica.
+	\item Test di \glossaryItem{validazione} (TV): viene verificato che il prodotto soddisfi quanto richiesto dal proponente individuando delle macro azioni che un utente svolge comunemente sul sistema;
+	\item Test di sistema (TS): sono test relativi al comportamento dell’intero sistema. Viene verificato che l'architettura generale funzioni complessivamente bene;
+	\item Test di integrazione (TI): vengono verificate le componenti del sistema contenute nella \SpecificaTecnica, ossia viene verificato che i \glossaryItem{package} siano funzionanti e in grado di funzionare nel loro insieme;
+	\item Test di unità (TU): viene testata ogni unità, ossia la più piccola parte di lavoro assegnabile ad un \glossaryItem{programmatore}. In questo \glossaryItem{progetto} una unità dovrebbe corrispondere ad una function o a un method;
+	\item Test di regressione (TR): possono essere test di tutte le tipologie succitate, e devono mostrare il funzionamento del prodotto a seguito di una modifica.
 \end{enumerate}
 
 	La seguente figura illustra come i test elencati vengono distribuiti durante in ciclo di vita del prodotto.
@@ -23,7 +23,7 @@
 	\end{figure}
 	
 
-\subsection{Test di Sistema}
+\subsection{Test di sistema}
 	Vengono qui descritti i test di sistema che andranno a verificare il funzionamento complessivo delle componenti. Nella seguente tabella, lo stato di ogni test è definito da N.E per non eseguito.
 
 	%table of testsTable

--- a/official/SpecificaTecnica/res/sections/activitiesDiagrams.tex
+++ b/official/SpecificaTecnica/res/sections/activitiesDiagrams.tex
@@ -3,7 +3,7 @@ In seguito vengono descritte le interazioni dell'utente con \glossaryItem{MaaS} 
 \begin{itemize}
 \item \textbf{Utente non autenticato};
 \item \textbf{Utente autenticato};
-\item \textbf{Super Admin}.
+\item \textbf{super admin}.
 \end{itemize}
 \subsection{Utente non autenticato}
 \begin{figure}[H]
@@ -289,19 +289,19 @@ Un Admin o un \glossaryItem{Owner} può aggiungere un database nella propria \gl
 \item porta di accesso;
 \item username e password per la lettura del database.
 \end{itemize}
-\subsection{Super Admin}
+\subsection{super admin}
 \begin{figure}[H]
 \begin{center}
 \includegraphics[height=12cm]{res/sections/backend/activities/principaliSuperAdmin.png}
-\caption{Attività principali per il Super Admin}
+\caption{Attività principali per il super admin}
 \end{center}
 \end{figure}
-Dopo aver effettuato il login, il Super Admin può:
+Dopo aver effettuato il login, il super admin può:
 \begin{itemize}
 \item creare una \glossaryItem{Company};
 \item visualizzare l'elenco delle \glossaryItem{Company} registrate a \glossaryItem{MaaS};
-\item aggiungere un altro Super Admin;
-\item visualizzare i dettagli sugli altri Super Admin.
+\item aggiungere un altro super admin;
+\item visualizzare i dettagli sugli altri super admin.
 \end{itemize}
 \subsubsection{Creazione Company}
 \begin{figure}[H]
@@ -310,7 +310,7 @@ Dopo aver effettuato il login, il Super Admin può:
 \caption{Creazione \glossaryItem{Company}}
 \end{center}
 \end{figure}
-Il Super Admin che crea una \glossaryItem{Company} deve fornire i dati dell'utente che verrà registrato come \glossaryItem{Owner}. È pertanto necessario fornire, durante la \glossaryItem{procedura} di creazione, l'indirizzo email e la password del nuovo utente, oltre che il nome della \glossaryItem{Company} stessa.
+Il super admin che crea una \glossaryItem{Company} deve fornire i dati dell'utente che verrà registrato come \glossaryItem{Owner}. È pertanto necessario fornire, durante la \glossaryItem{procedura} di creazione, l'indirizzo email e la password del nuovo utente, oltre che il nome della \glossaryItem{Company} stessa.
 \subsubsection{Visualizzazione elenco Companies}
 \begin{figure}[H]
 \begin{center}
@@ -318,7 +318,7 @@ Il Super Admin che crea una \glossaryItem{Company} deve fornire i dati dell'uten
 \caption{Visualizzazione elenco Companies}
 \end{center}
 \end{figure}
-Il Super Admin può visualizzare tutte le \glossaryItem{Company} presenti in \glossaryItem{MaaS}, ed eseguire varie operazioni su di esse:
+Il super admin può visualizzare tutte le \glossaryItem{Company} presenti in \glossaryItem{MaaS}, ed eseguire varie operazioni su di esse:
 \begin{itemize}
 \item modificare i dati della \glossaryItem{Company};
 \item aggiungere un utente;
@@ -332,7 +332,7 @@ Il Super Admin può visualizzare tutte le \glossaryItem{Company} presenti in \gl
 \caption{Modifica dei dati di una \glossaryItem{Company}}
 \end{center}
 \end{figure}
-Il Super Admin può modificare il nome di una \glossaryItem{Company} inserendo il nuovo nome in una casella di testo ed inviando la richiesta di aggiornamento tramite un pulsante presente sulla pagina.
+Il super admin può modificare il nome di una \glossaryItem{Company} inserendo il nuovo nome in una casella di testo ed inviando la richiesta di aggiornamento tramite un pulsante presente sulla pagina.
 \newpage
 \paragraph{Aggiunta utente} \mbox{} \\
 \begin{figure}[H]
@@ -341,7 +341,7 @@ Il Super Admin può modificare il nome di una \glossaryItem{Company} inserendo i
 \caption{Aggiunta di un utente alla \glossaryItem{Company}}
 \end{center}
 \end{figure}
-Il Super Admin può aggiungere un utente alla \glossaryItem{Company} selezionata inserendone indirizzo email, password e ruolo. 
+Il super admin può aggiungere un utente alla \glossaryItem{Company} selezionata inserendone indirizzo email, password e ruolo. 
 \paragraph{Visualizzazione utenti della Company} \mbox{} \\
 \begin{figure}[H]
 \begin{center}
@@ -349,20 +349,20 @@ Il Super Admin può aggiungere un utente alla \glossaryItem{Company} selezionata
 \caption{Visualizzazione utenti della \glossaryItem{Company}}
 \end{center}
 \end{figure}
-Una volta visualizato l'elenco degli utenti iscritti alla \glossaryItem{Company}, il Super Admin può modificare il ruolo di un utente o di rimuoverlo. Nel secondo caso è richiesta una conferma, per evitare eliminazioni accidentali.
-\subsubsection{Aggiunta di un Super Admin}
+Una volta visualizato l'elenco degli utenti iscritti alla \glossaryItem{Company}, il super admin può modificare il ruolo di un utente o di rimuoverlo. Nel secondo caso è richiesta una conferma, per evitare eliminazioni accidentali.
+\subsubsection{Aggiunta di un super admin}
 \begin{figure}[H]
 \begin{center}
 \includegraphics[height=12cm]{res/sections/backend/activities/aggiuntaSuperAdmin.png}
-\caption{Aggiunta Super Admin}
+\caption{Aggiunta super admin}
 \end{center}
 \end{figure}
-Il Super Admin può inserire un altro Super Admin all'intero di \glossaryItem{MaaS}, per farlo è necessario fornirne indirizzo email e password, ed inviare i dati attraverso un apposito pulsante.
-\subsubsection{Visualizzazione dettagli di un Super Admin}
+Il super admin può inserire un altro super admin all'intero di \glossaryItem{MaaS}, per farlo è necessario fornirne indirizzo email e password, ed inviare i dati attraverso un apposito pulsante.
+\subsubsection{Visualizzazione dettagli di un super admin}
 \begin{figure}[H]
 \begin{center}
 \includegraphics[height=12cm]{res/sections/backend/activities/visualizzazioneDettagliSuperAdminSA.png}
-\caption{Visualizzazione altri Super Admins}
+\caption{Visualizzazione altri super admins}
 \end{center}
 \end{figure}
-Il Super Admin può visualizzare i dettagli sugli altri Super Admin a partire dalla pagina di elenco dei Super Admin presenti in \glossaryItem{MaaS}. Per fare questo è sufficiente fare click sul Super Admin del quale si vogliono visualizzare i dettagli.
+Il super admin può visualizzare i dettagli sugli altri super admin a partire dalla pagina di elenco dei super admin presenti in \glossaryItem{MaaS}. Per fare questo è sufficiente fare click sul super admin del quale si vogliono visualizzare i dettagli.

--- a/official/SpecificaTecnica/res/sections/activitiesDiagrams.tex
+++ b/official/SpecificaTecnica/res/sections/activitiesDiagrams.tex
@@ -362,7 +362,7 @@ Il super admin può inserire un altro super admin all'intero di \glossaryItem{Ma
 \begin{figure}[H]
 \begin{center}
 \includegraphics[height=12cm]{res/sections/backend/activities/visualizzazioneDettagliSuperAdminSA.png}
-\caption{Visualizzazione altri super admins}
+\caption{Visualizzazione altri super admin}
 \end{center}
 \end{figure}
 Il super admin può visualizzare i dettagli sugli altri super admin a partire dalla pagina di elenco dei super admin presenti in \glossaryItem{MaaS}. Per fare questo è sufficiente fare click sul super admin del quale si vogliono visualizzare i dettagli.


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #280 

_Breve descrizione della soluzione adottata_: 
Sistemate le iniziali dei titoli. 
In particolare il nome degli attori sono stati portati in minuscolo,il primo carattere di ogni titolo in maiuscolo mentre il resto in minuscolo(tranne nel caso in cui siano elementi integrati di MaaS o acronimi).
