### PR TITLE
Issue#281

### DIFF
--- a/official/AnalisiDeiRequisiti/main.tex
+++ b/official/AnalisiDeiRequisiti/main.tex
@@ -14,6 +14,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}

--- a/official/NormeDiProgetto/main.tex
+++ b/official/NormeDiProgetto/main.tex
@@ -14,6 +14,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}

--- a/official/PianoDiProgetto/main.tex
+++ b/official/PianoDiProgetto/main.tex
@@ -15,6 +15,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}

--- a/official/PianoDiQualifica/main.tex
+++ b/official/PianoDiQualifica/main.tex
@@ -14,6 +14,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}

--- a/official/SpecificaTecnica/main.tex
+++ b/official/SpecificaTecnica/main.tex
@@ -14,6 +14,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}

--- a/official/StudioDiFattibilita/main.tex
+++ b/official/StudioDiFattibilita/main.tex
@@ -14,6 +14,8 @@
 \makeFrontPage
 
 \tableofcontents
+\listoffigures
+\listoftables
 
 \include{res/versions}
 \include{res/listOfSections}


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #281 

_Breve descrizione della soluzione adottata_:
Aggiunta indice figure e tabelle per i seguenti documenti:
- Analisi dei requisiti
- Norme di progetto
- Piano di progetto
- Studio di fattibilita'
- Piano di qualifica
- Specifica tecnica

Non ho ritenuto necessario aggiungere per i seguenti documenti:
- Lettera di Presentazione
- Glossario

_Nota_: se non sono presenti delle `\caption` nelle tabelle o nelle immagini queste **NON** verranno visualizzate nell'indice. E' quindi necessario mettere il `\caption` in tutte le tabelle e le figure in cui manca per avere una indicizzazione totale.
