### PR TITLE
Issue#385 - Fix issue with double =

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ zip:
 	for i in $(wildcard official/*/*.pdf); do \
 		pathFile=`dirname $$i`; \
 		nameFile=`basename \`dirname $$i\``; \
-		if [ "$$pathFile" == "official/NormeDiProgetto" ]; then \
+		if [ "$$pathFile" = "official/NormeDiProgetto" ]; then \
 			cp $$i $(PATH_ZIP)/Interni/$$nameFile.pdf; \
 		else \
 			cp $$i $(PATH_ZIP)/Esterni/$$nameFile.pdf; \


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #385 

_Breve descrizione della soluzione adottata_:
Sostituito i doppi = con un solo = per compatibilita' con la `shell`
