### PR TITLE
Issue#543 - No more apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 sudo: required
 
 install:
-- sudo apt-get update
 - sudo apt-get install texlive-latex-extra -qq
 - sudo apt-get install texlive-luatex -qq
 - sudo apt-get install cm-super -qq


### PR DESCRIPTION
_Numero del Task/Issue correlato/a_: #543 

_Breve descrizione della soluzione adottata_:
Build non rese container-based in quanto non sono disponibili i pacchetti per le build di documenti latex. Rimosso `apt-get update` per evitare che le build vadano in uno stato `erroned`
